### PR TITLE
Update `label-component` workflow job

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -6,8 +6,7 @@ policy:
         label:
           - name: 'documentation'
             keys: ['Yes']
-  
-         
+
       - id: [diagrams]
         block-list: ['None']
         label:
@@ -35,5 +34,3 @@ policy:
             keys: ['User journey']
           - name: diagram-all
             keys: ['All diagrams']
-        
-       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,16 @@
 name: Issue labeler
 on:
   issues:
-    types: [ opened, edited ]
+    types: [ opened ]
 
 jobs:
   label-component:
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        template: [ bug_mermaid.yml ]
+    
     steps:
       - uses: actions/checkout@v3
 
@@ -13,18 +18,11 @@ jobs:
         uses: stefanbuck/github-issue-parser@v2
         id: issue-parser
         with:
-          template-path: .github/ISSUE_TEMPLATE/bug_mermaid.yml
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
-      - name: Set documentation label if topic_documentation = 'Yes'
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@latest
+      - name: Set documentation label if topic_documentation = 'Yes' & Set diagram type label
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          section: topic_documentation
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set diagram type label from diagrams values
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@latest
-        with:
-          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          section: diagrams
+          template: ${{ matrix.template }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have noticed that you have started using `redhat-plumbers-in-action/advanced-issue-labeler`. Unfortunately you are using an unsupported combination of options. The following patch should fix the current issue, and issue labeling should start to work.

- https://github.com/jamacku/rails-guides-bookstore-models/issues/3

I plan to update the documentation to mark options that don't work well together visibly. Feel free to ping me If you encounter any issues.